### PR TITLE
Avoid error when clicking sort on users_count column

### DIFF
--- a/models/usergroup/columns.yaml
+++ b/models/usergroup/columns.yaml
@@ -23,3 +23,4 @@ columns:
         relation: users_count
         valueFrom: count
         default: 0
+        sortable: false


### PR DESCRIPTION
When the sort icon is clicked on the USERS column of the UserGroup list an error is returned. Subsequent requests to this page will result an in error because it is saved as the users preference to sort by this column. Setting the sortable attribute to false for this column resolves this problem.
